### PR TITLE
Fixes to allow building the module with Microsoft VC compiler

### DIFF
--- a/codetalker/c/_speed_tokens.c
+++ b/codetalker/c/_speed_tokens.c
@@ -7,6 +7,12 @@
 #include "string.h"
 #include "_speed_tokens.h"
 
+#if defined(_WIN32) || defined(_WIN64) || defined(_MSC_VERS)
+#ifndef strncasecmp
+#define strncasecmp _strnicmp
+#endif
+#endif
+
 /**
  * Backend code for tokenizing strings
  */
@@ -20,11 +26,12 @@
  * Returns the number of characters consumed (0 for invalid)
  */
 int t_tstring(int at, char* text, int ln) {
+    char which;
     int i = at;
     if (ln < at + 6 || (text[i] != '\'' && text[i] != '"')) {
         return 0;
     }
-    char which = text[i];
+    which = text[i];
     if (text[i+1] != which || text[i+2] != which) {
         return 0;
     }
@@ -124,7 +131,7 @@ int t_id(int at, char* text, int ln, char* idchars) {
  * Returns the number of characters consumed (0 for invalid)
  */
 int t_number(int at, char* text, int ln) {
-    int i = at;
+    int pre, i = at;
     if (text[i] == '-') i++;
     if (i >= ln) return 0;
     if (text[i] == '.') {
@@ -148,7 +155,7 @@ int t_number(int at, char* text, int ln) {
     } else {
         return 0;
     }
-    int pre = i;
+    pre = i;
     if (i < ln-2 && (text[i] == 'e' || text[i] == 'E')) {
         i++;
         if (text[i] == '+' || text[i] == '-') {

--- a/codetalker/c/parser.c
+++ b/codetalker/c/parser.c
@@ -508,19 +508,13 @@ struct Token* c_get_tokens(struct Grammar* grammar, char* text, int indent, stru
     struct Token* start = NULL;
     struct Token* current = NULL;
     struct Token* tmp = NULL;
-
-    struct TokenState state;
     struct PToken ptoken;
-
     int ID_t = grammar->tokens.num;
     int DD_t = grammar->tokens.num+1;
-
-
-
     int res = 0;
-
-
     int dirty;
+
+    struct TokenState state;    
     state.at = 0;
     state.ln = strlen(text);
     // state.text = text;


### PR DESCRIPTION
MSVC is stupid and throws an error during build if you declare a variable anywhere but at the top of a function. Additionally, strncmp is not defined in the MSVC standard headers. To fix these two issues, I moved a couple of variable declarations to the top of their function, and threw in a quick macro so that if the user is compiling the source code from MSVC, it will use _strnicmp instead of strncmp. (Same thing)
