### PR TITLE
Remove print statement for rules.py

### DIFF
--- a/codetalker/pgm/rules.py
+++ b/codetalker/pgm/rules.py
@@ -30,7 +30,7 @@ class RuleLoader(object):
             return [what]
         elif inspect.isclass(what) and issubclass(what, Token):
             if what not in self.grammar.tokens and what not in self.grammar.special_tokens:
-                print 'adding', what
+                # print 'adding', what
                 self.grammar.tokens.append(what)
             return [what]
             # return [-(self.grammar.tokens.index(what) + 1)]


### PR DESCRIPTION
Remove the print statement from rules.py that is dumped on stdout which is not very clean for scripts and other processes using this awesome library. If logging is required please comment on this pull request and i will add it.